### PR TITLE
Add encryption API to sidecar service

### DIFF
--- a/sidecar-service/src/main/java/com/example/sidecar/controller/EncryptionController.java
+++ b/sidecar-service/src/main/java/com/example/sidecar/controller/EncryptionController.java
@@ -1,0 +1,36 @@
+package com.example.sidecar.controller;
+
+import com.example.sidecar.model.EncryptRequest;
+import com.example.sidecar.model.EncryptResponse;
+import com.example.sidecar.service.CryptoService;
+
+import jakarta.validation.Valid;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@Validated
+public class EncryptionController {
+
+    private static final Logger log = LoggerFactory.getLogger(EncryptionController.class);
+    private final CryptoService cryptoService;
+
+    public EncryptionController(CryptoService cryptoService) {
+        this.cryptoService = cryptoService;
+    }
+
+    @PostMapping("/encrypt")
+    public ResponseEntity<EncryptResponse> encrypt(@Valid @RequestBody EncryptRequest request) {
+        log.info("Received REST encryption request for keyId={}", request.keyId());
+        String cipherText = cryptoService.encrypt(request.keyId(), request.plainText());
+        return ResponseEntity.ok(new EncryptResponse(cipherText));
+    }
+}

--- a/sidecar-service/src/main/java/com/example/sidecar/model/EncryptRequest.java
+++ b/sidecar-service/src/main/java/com/example/sidecar/model/EncryptRequest.java
@@ -1,0 +1,9 @@
+package com.example.sidecar.model;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record EncryptRequest(
+        @NotBlank(message = "keyId is required") String keyId,
+        @NotBlank(message = "plainText is required") String plainText
+) {
+}

--- a/sidecar-service/src/main/java/com/example/sidecar/model/EncryptResponse.java
+++ b/sidecar-service/src/main/java/com/example/sidecar/model/EncryptResponse.java
@@ -1,0 +1,4 @@
+package com.example.sidecar.model;
+
+public record EncryptResponse(String cipherText) {
+}

--- a/sidecar-service/src/test/java/com/example/sidecar/service/CryptoServiceTest.java
+++ b/sidecar-service/src/test/java/com/example/sidecar/service/CryptoServiceTest.java
@@ -51,4 +51,23 @@ class CryptoServiceTest {
         assertThat(first).isEqualTo(second).isEqualTo("repeatable-secret");
         assertThat(mockKmsClient.getLookupCount()).isEqualTo(1);
     }
+
+    @Test
+    void encryptShouldProduceDecryptableCiphertext() {
+        String cipherText = cryptoService.encrypt(KEY_ID, "top-secret-order");
+
+        String decrypted = cryptoService.decrypt(KEY_ID, cipherText);
+
+        assertThat(decrypted).isEqualTo("top-secret-order");
+    }
+
+    @Test
+    void encryptShouldReuseCachedSecretKey() {
+        mockKmsClient.resetCounter();
+
+        cryptoService.encrypt(KEY_ID, "order-1");
+        cryptoService.encrypt(KEY_ID, "order-2");
+
+        assertThat(mockKmsClient.getLookupCount()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
## Summary
- add AES-GCM encryption support to the CryptoService and expose it via a new REST endpoint
- define request/response models for encryption payloads
- expand CryptoService tests to cover encryption flow and key caching reuse

## Testing
- mvn -pl sidecar-service test *(fails: unable to download dependencies from Maven Central due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e786b82aa0832792a2743d94349c2d